### PR TITLE
feat: Implement pluggable AI model architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ This project implements a command-line Retrieval Augmented Generation (RAG) chat
 ## Features
 
 - Answers questions based on the content of `training_data.txt`.
-- Uses OpenAI for language understanding and generation.
-- Uses OpenAI embeddings and a local vector store (ChromaDB or FAISS) for efficient retrieval.
+- Uses OpenAI for language understanding and generation (by default).
+- Uses OpenAI embeddings (by default) and a local vector store (ChromaDB or FAISS) for efficient retrieval.
+- Pluggable AI model architecture (currently supporting OpenAI, with placeholders for Google Jules and MCP).
 
 ## Setup and Usage
 
@@ -15,18 +16,43 @@ This project implements a command-line Retrieval Augmented Generation (RAG) chat
 - Access to an OpenAI API key.
 
 ### 2. Environment Variables
-You **must** set your OpenAI API key as an environment variable.
+You need to configure environment variables to specify your chosen AI model provider and the necessary API keys.
+
+-   **`OPENAI_API_KEY`**: Required if using the OpenAI model (default). Replace `your_actual_openai_api_key_here` with your real key.
+-   **`AI_MODEL_PROVIDER`**: Specifies which AI model to use.
+    -   Supported values: `OPENAI` (default), `JULES`, `MCP`.
+    -   Example: `export AI_MODEL_PROVIDER='OPENAI'`
+-   **`JULES_API_KEY`**: (Future Use) Will be required if `AI_MODEL_PROVIDER` is set to `JULES` once the model is implemented. For now, a dummy value is used if not set.
+-   **`MCP_API_KEY`**: (Future Use) Will be required if `AI_MODEL_PROVIDER` is set to `MCP` once the model is implemented. For now, a dummy value is used if not set.
+
 
 **Linux/macOS:**
 ```bash
 export OPENAI_API_KEY='your_actual_openai_api_key_here'
+export AI_MODEL_PROVIDER='OPENAI' # Or 'JULES', 'MCP'
+# export JULES_API_KEY='your_jules_key_here' # When Jules is implemented
+# export MCP_API_KEY='your_mcp_key_here'     # When MCP is implemented
 ```
 
 **Windows (PowerShell):**
 ```powershell
 $Env:OPENAI_API_KEY='your_actual_openai_api_key_here'
+$Env:AI_MODEL_PROVIDER='OPENAI' # Or 'JULES', 'MCP'
+# $Env:JULES_API_KEY='your_jules_key_here' # When Jules is implemented
+# $Env:MCP_API_KEY='your_mcp_key_here'     # When MCP is implemented
 ```
-Replace `your_actual_openai_api_key_here` with your real key. You might want to add this line to your shell's profile file (e.g., `.bashrc`, `.zshrc`, or PowerShell profile) for persistence.
+You might want to add these lines to your shell's profile file (e.g., `.bashrc`, `.zshrc`, or PowerShell profile) for persistence.
+
+## AI Model Configuration
+
+This application supports a pluggable AI model architecture, allowing you to choose from different AI providers. The selection is controlled by the `AI_MODEL_PROVIDER` environment variable.
+
+-   **`AI_MODEL_PROVIDER`**:
+    -   `OPENAI`: Uses OpenAI's models for embeddings and language generation. Requires `OPENAI_API_KEY`. This is the default if the variable is not set.
+    -   `JULES`: Placeholder for a hypothetical "Jules" AI model. Currently, this is a non-functional placeholder. If selected, the application will indicate this and will not be able to process queries.
+    -   `MCP`: Placeholder for a hypothetical "MCP" AI model. Similar to `JULES`, this is a non-functional placeholder.
+
+The core abstraction is defined in `ai_models.py` with the `AIModel` base class. Developers can extend this by adding new classes that implement the required methods (`get_embeddings`, `generate_response`) for other AI services.
 
 ### 3. Training Data
 - Locate the `training_data.txt` file in the root directory of this project.
@@ -61,6 +87,3 @@ These dependencies are listed in `requirements.txt`. Due to potential environmen
 pip install langchain openai langchain_community tiktoken faiss-cpu chromadb
 ```
 (Note: `faiss-cpu` and `chromadb` are the primary vector store options the script tries. You might only need one depending on what works in your environment.)
-
----
-# AI-Agent

--- a/ai_models.py
+++ b/ai_models.py
@@ -1,0 +1,166 @@
+# Import the abc module to define abstract methods
+from abc import ABC, abstractmethod
+
+class AIModel(ABC):
+  """
+  Base class for AI models.
+
+  This class defines the basic structure for AI models, including methods for
+  getting embeddings and generating responses.
+  """
+
+  def __init__(self, api_key: str):
+    """
+    Initializes the AIModel with an API key.
+
+    Args:
+      api_key: The API key for accessing the AI model.
+    """
+    self.api_key = api_key
+
+  @abstractmethod
+  def get_embeddings(self, texts: list[str]) -> list[list[float]]:
+    """
+    Gets embeddings for a list of texts.
+
+    This method should be implemented by subclasses to provide specific
+    functionality for getting embeddings from the AI model.
+
+    Args:
+      texts: A list of strings to get embeddings for.
+
+    Returns:
+      A list of embeddings, where each embedding is a list of floats.
+    """
+    pass
+
+# Import necessary modules from langchain_openai
+from langchain_openai import OpenAIEmbeddings, OpenAI
+
+class OpenAIModel(AIModel):
+  """
+  Implementation of AIModel using OpenAI's models.
+  """
+
+  def __init__(self, api_key: str):
+    """
+    Initializes the OpenAIModel with an API key.
+
+    Args:
+      api_key: The API key for accessing OpenAI models.
+    """
+    super().__init__(api_key)
+    self.embeddings_model = OpenAIEmbeddings(openai_api_key=api_key)
+    self.llm_model = OpenAI(openai_api_key=api_key)
+
+  def get_embeddings(self) -> OpenAIEmbeddings:
+    """
+    Returns the OpenAIEmbeddings instance.
+
+    This instance can be used by Langchain components that require an
+    Embeddings object (e.g., vector stores).
+
+    Returns:
+      An OpenAIEmbeddings instance.
+    """
+    return self.embeddings_model
+
+  def generate_response(self) -> OpenAI:
+    """
+    Returns the OpenAI (LLM) instance.
+
+    This instance can be used by Langchain components that require an
+    LLM object (e.g., RetrievalQA chain).
+
+    Returns:
+      An OpenAI instance.
+    """
+    return self.llm_model
+
+class JulesModel(AIModel):
+  """
+  Placeholder implementation of AIModel for a hypothetical Jules AI.
+
+  This class is intended to be a skeleton. Actual implementation would
+  require integrating with the Jules AI API/SDK for embeddings and response
+  generation.
+  """
+
+  def __init__(self, api_key: str):
+    """
+    Initializes the JulesModel with an API key.
+
+    Args:
+      api_key: The API key for accessing Jules AI models (if applicable).
+    """
+    super().__init__(api_key)
+    print(f"JulesModel initialized with API key: {'*' * len(api_key) if api_key else 'Not provided'}")
+    # Future: Initialize Jules AI specific clients or settings
+
+  def get_embeddings(self): # type: ignore
+    """
+    Placeholder for getting embeddings from Jules AI.
+
+    Returns:
+      None, as this is a placeholder.
+    """
+    print("JulesModel: get_embeddings called. This is a placeholder and not implemented.")
+    # In a real implementation, this would call Jules AI's embedding API/SDK
+    # and return an object compatible with Langchain's vector stores.
+    raise NotImplementedError("JulesModel.get_embeddings is not implemented.")
+
+  def generate_response(self): # type: ignore
+    """
+    Placeholder for generating responses from Jules AI.
+
+    Returns:
+      None, as this is a placeholder.
+    """
+    print("JulesModel: generate_response called. This is a placeholder and not implemented.")
+    # In a real implementation, this would call Jules AI's language model
+    # and return an object compatible with Langchain's QA chains.
+    raise NotImplementedError("JulesModel.generate_response is not implemented.")
+
+class MCPModel(AIModel):
+  """
+  Placeholder implementation of AIModel for a hypothetical MCP AI.
+
+  This class is intended to be a skeleton. Actual implementation would
+  require integrating with the MCP AI API/SDK for embeddings and response
+  generation.
+  """
+
+  def __init__(self, api_key: str):
+    """
+    Initializes the MCPModel with an API key.
+
+    Args:
+      api_key: The API key for accessing MCP AI models (if applicable).
+    """
+    super().__init__(api_key)
+    print(f"MCPModel initialized with API key: {'*' * len(api_key) if api_key else 'Not provided'}")
+    # Future: Initialize MCP AI specific clients or settings
+
+  def get_embeddings(self): # type: ignore
+    """
+    Placeholder for getting embeddings from MCP AI.
+
+    Returns:
+      None, as this is a placeholder.
+    """
+    print("MCPModel: get_embeddings called. This is a placeholder and not implemented.")
+    # In a real implementation, this would call MCP AI's embedding API/SDK
+    # and return an object compatible with Langchain's vector stores.
+    raise NotImplementedError("MCPModel.get_embeddings is not implemented.")
+
+  def generate_response(self): # type: ignore
+    """
+    Placeholder for generating responses from MCP AI.
+
+    Returns:
+      None, as this is a placeholder.
+    """
+    print("MCPModel: generate_response called. This is a placeholder and not implemented.")
+    # In a real implementation, this would call MCP AI's language model
+    # and return an object compatible with Langchain's QA chains.
+    raise NotImplementedError("MCPModel.generate_response is not implemented.")

--- a/test_ai_models.py
+++ b/test_ai_models.py
@@ -1,0 +1,163 @@
+import unittest
+import os
+import importlib # Added for reloading rag_chatbot
+from unittest.mock import patch, MagicMock
+
+# Import classes to be tested
+from ai_models import AIModel, OpenAIModel, JulesModel, MCPModel
+
+# Imports for type checking and mocking internal components if necessary
+from langchain_openai import OpenAIEmbeddings
+from langchain_openai import OpenAI
+
+# Import the module containing the main logic for model selection
+# We need to be careful here if rag_chatbot.py has side effects on import
+# or relies heavily on environment variables being set at module level.
+# For now, we'll import it directly.
+import rag_chatbot
+
+class TestOpenAIModel(unittest.TestCase):
+    def test_initialization_and_getters(self):
+        """Test OpenAIModel initialization and its getter methods."""
+        # Provide a dummy API key for initialization
+        dummy_api_key = "sk-testkey123"
+        model = OpenAIModel(api_key=dummy_api_key)
+
+        # Check if get_embeddings() returns an instance of OpenAIEmbeddings
+        self.assertIsInstance(model.get_embeddings(), OpenAIEmbeddings,
+                              "get_embeddings() should return an OpenAIEmbeddings instance.")
+
+        # Check if generate_response() returns an instance of OpenAI (the LLM)
+        self.assertIsInstance(model.generate_response(), OpenAI,
+                              "generate_response() should return an OpenAI LLM instance.")
+
+class TestJulesModel(unittest.TestCase):
+    def test_placeholder_methods(self):
+        """Test JulesModel placeholder methods raise NotImplementedError."""
+        dummy_api_key = "jules-testkey123" # Dummy key, as it's a placeholder
+        model = JulesModel(api_key=dummy_api_key)
+
+        with self.assertRaises(NotImplementedError, msg="JulesModel.get_embeddings should raise NotImplementedError"):
+            model.get_embeddings()
+
+        with self.assertRaises(NotImplementedError, msg="JulesModel.generate_response should raise NotImplementedError"):
+            model.generate_response()
+
+class TestMCPModel(unittest.TestCase):
+    def test_placeholder_methods(self):
+        """Test MCPModel placeholder methods raise NotImplementedError."""
+        dummy_api_key = "mcp-testkey123" # Dummy key, as it's a placeholder
+        model = MCPModel(api_key=dummy_api_key)
+
+        with self.assertRaises(NotImplementedError, msg="MCPModel.get_embeddings should raise NotImplementedError"):
+            model.get_embeddings()
+
+        with self.assertRaises(NotImplementedError, msg="MCPModel.generate_response should raise NotImplementedError"):
+            model.generate_response()
+
+
+class TestChatbotModelSelection(unittest.TestCase):
+
+    def _run_main_logic_for_test(self):
+        """
+        Helper to encapsulate the call to rag_chatbot.main() and expected error handling.
+        This avoids repeating the try-except block in each test.
+        """
+        try:
+            rag_chatbot.main()
+        except (NotImplementedError, RuntimeError, ValueError, SystemExit) as e:
+            # Catch errors from placeholder models, missing keys if not mocked, or SystemExit if main exits early.
+            print(f"Caught expected exception/exit in test: {e}")
+            pass
+
+    @patch('rag_chatbot.load_documents', return_value=[MagicMock()])
+    @patch('rag_chatbot.split_documents', return_value=[MagicMock()])
+    @patch('rag_chatbot.setup_rag_pipeline')
+    @patch('ai_models.OpenAIModel')
+    def test_select_openai_model(self, MockOpenAIModelConstructor, mock_setup_rag, mock_split, mock_load):
+        with patch('os.getenv') as mock_getenv:
+            mock_getenv.side_effect = lambda key, default=None: {
+                'AI_MODEL_PROVIDER': 'OPENAI',
+                'OPENAI_API_KEY': 'fake_openai_key'
+            }.get(key, default)
+            with patch.dict(rag_chatbot.os.environ, {'OPENAI_API_KEY': 'fake_openai_key'}): # This helps for os.environ access within main
+                rag_chatbot.OPENAI_API_KEY = 'fake_openai_key' # Set module level variable directly
+                importlib.reload(rag_chatbot) # Reload to apply mock to module-level getenv
+                self._run_main_logic_for_test()
+                MockOpenAIModelConstructor.assert_called_once_with(api_key='fake_openai_key')
+
+    @patch('rag_chatbot.load_documents', return_value=[MagicMock()])
+    @patch('rag_chatbot.split_documents', return_value=[MagicMock()])
+    @patch('rag_chatbot.setup_rag_pipeline')
+    @patch('ai_models.JulesModel')
+    def test_select_jules_model(self, MockJulesModelConstructor, mock_setup_rag, mock_split, mock_load):
+        with patch('os.getenv') as mock_getenv:
+            mock_getenv.side_effect = lambda key, default=None: {
+                'AI_MODEL_PROVIDER': 'JULES',
+                'JULES_API_KEY': 'fake_jules_key',
+                'OPENAI_API_KEY': 'fake_openai_key'
+            }.get(key, default)
+            with patch.dict(rag_chatbot.os.environ, {'OPENAI_API_KEY': 'fake_openai_key'}):
+                rag_chatbot.OPENAI_API_KEY = 'fake_openai_key'
+                importlib.reload(rag_chatbot)
+                self._run_main_logic_for_test()
+                MockJulesModelConstructor.assert_called_once_with(api_key='fake_jules_key')
+
+    @patch('rag_chatbot.load_documents', return_value=[MagicMock()])
+    @patch('rag_chatbot.split_documents', return_value=[MagicMock()])
+    @patch('rag_chatbot.setup_rag_pipeline')
+    @patch('ai_models.MCPModel')
+    def test_select_mcp_model(self, MockMCPModelConstructor, mock_setup_rag, mock_split, mock_load):
+        with patch('os.getenv') as mock_getenv:
+            mock_getenv.side_effect = lambda key, default=None: {
+                'AI_MODEL_PROVIDER': 'MCP',
+                'MCP_API_KEY': 'fake_mcp_key',
+                'OPENAI_API_KEY': 'fake_openai_key'
+            }.get(key, default)
+            with patch.dict(rag_chatbot.os.environ, {'OPENAI_API_KEY': 'fake_openai_key'}):
+                rag_chatbot.OPENAI_API_KEY = 'fake_openai_key'
+                importlib.reload(rag_chatbot)
+                self._run_main_logic_for_test()
+                MockMCPModelConstructor.assert_called_once_with(api_key='fake_mcp_key')
+
+    @patch('rag_chatbot.load_documents', return_value=[MagicMock()])
+    @patch('rag_chatbot.split_documents', return_value=[MagicMock()])
+    @patch('rag_chatbot.setup_rag_pipeline')
+    @patch('ai_models.OpenAIModel')
+    def test_select_default_model(self, MockOpenAIModelConstructor, mock_setup_rag, mock_split, mock_load):
+        with patch('os.getenv') as mock_getenv:
+            mock_getenv.side_effect = lambda key, default=None: {
+                'OPENAI_API_KEY': 'fake_openai_key'
+            }.get(key, default)
+            with patch.dict(rag_chatbot.os.environ, {'OPENAI_API_KEY': 'fake_openai_key'}):
+                rag_chatbot.OPENAI_API_KEY = 'fake_openai_key'
+                importlib.reload(rag_chatbot)
+                self._run_main_logic_for_test()
+                MockOpenAIModelConstructor.assert_called_once_with(api_key='fake_openai_key')
+
+    @patch('rag_chatbot.load_documents', return_value=[MagicMock()])
+    @patch('rag_chatbot.split_documents', return_value=[MagicMock()])
+    @patch('rag_chatbot.setup_rag_pipeline')
+    @patch('builtins.print')
+    @patch('ai_models.OpenAIModel')
+    @patch('ai_models.JulesModel')
+    @patch('ai_models.MCPModel')
+    def test_select_unknown_model_provider(self, MockMCPModel, MockJulesModel, MockOpenAIModel, mock_print, mock_setup_rag, mock_split, mock_load):
+        with patch('os.getenv') as mock_getenv:
+            mock_getenv.side_effect = lambda key, default=None: {
+                'AI_MODEL_PROVIDER': 'UNKNOWN_PROVIDER',
+                'OPENAI_API_KEY': 'fake_openai_key'
+            }.get(key, default)
+            with patch.dict(rag_chatbot.os.environ, {'OPENAI_API_KEY': 'fake_openai_key'}):
+                rag_chatbot.OPENAI_API_KEY = 'fake_openai_key'
+                importlib.reload(rag_chatbot)
+                self._run_main_logic_for_test()
+
+                MockOpenAIModel.assert_not_called()
+                MockJulesModel.assert_not_called()
+                MockMCPModel.assert_not_called()
+                # Check if the specific error print for unknown provider was called
+                mock_print.assert_any_call("Error: Unknown AI_MODEL_PROVIDER 'UNKNOWN_PROVIDER'. Please use 'OPENAI', 'JULES', or 'MCP'.")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This change introduces a flexible architecture for using multiple AI models within the RAG chatbot.

Key changes:
- Added an `AIModel` base class in `ai_models.py` defining an interface for AI operations (embedding and response generation).
- Refactored `rag_chatbot.py` to use this abstraction.
- Implemented `OpenAIModel` as the first concrete implementation of `AIModel`.
- Added placeholder implementations for `JulesModel` (Google Jules) and `MCPModel`.
- Introduced an `AI_MODEL_PROVIDER` environment variable to allow you to select the desired AI model (OpenAI, Jules, or MCP). OpenAI is the default.
- Updated `README.md` to document the new multi-model support and configuration.
- Added comprehensive unit tests for the new model classes and the model selection logic in `rag_chatbot.py`.

This lays the groundwork for easily integrating and switching between different AI providers in the future. The Jules and MCP models are currently placeholders and will require full API/SDK integration to be functional.